### PR TITLE
Set up autocomplete properly with autosuggestions

### DIFF
--- a/config.json
+++ b/config.json
@@ -44,6 +44,11 @@
       "label": "Create Ghostty config directory",
       "command": "/bin/bash $DOTFILES/ghostty/init",
       "sudo": false
+    },
+    {
+      "label": "Install zsh autosuggestions",
+      "command": "git clone https://github.com/zsh-users/zsh-autosuggestions ~/.zsh/zsh-autosuggestions && echo 'source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh' >> ~/.zshrc",
+      "sudo": false
     }
 
   ],

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -35,6 +35,8 @@ fi
 # - Gives the terminal a list of command menus and bit more info
 source /opt/homebrew/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh
 
+# Remap Shift+TAB to zsh-autocomplete menu first item
+bindkey -M menuselect '^[[Z' reverse-menu-complete
 
 # Native Zsh auto completion setup
 # Docs here: https://zsh.sourceforge.io/Doc/Release/Options.html
@@ -52,13 +54,6 @@ source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
 
 # Remap TAB to native completion
 bindkey '^I' expand-or-complete
-setopt auto_menu
-
-# Remap Shift+TAB to zsh-autocomplete menu
-# bindkey '^[[Z' zsh-autocomplete-widget
-
-bindkey -M menuselect '^[[Z' reverse-menu-complete
-
 
 # Autojump - added from brew install info
 [ -f /opt/homebrew/etc/profile.d/autojump.sh ] && . /opt/homebrew/etc/profile.d/autojump.sh
@@ -99,3 +94,9 @@ esac
 # pnpm end
 export PATH="$HOME/.local/bin:$PATH"
 export PATH="/usr/local/bin:$PATH"
+
+##################################
+## Aliases                     ##
+##################################
+
+alias ..='cd ..'

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -59,3 +59,14 @@ if which jenv > /dev/null; then eval "$(jenv init -)"; fi
 # Intellij
 export PATH="/Applications/IntelliJ IDEA.app/Contents/bin:$PATH"
 
+# pnpm
+export PNPM_HOME="/Users/aas/Library/pnpm"
+case ":$PATH:" in
+  *":$PNPM_HOME:"*) ;;
+  *) export PATH="$PNPM_HOME:$PATH" ;;
+esac
+# pnpm end
+export PATH="$HOME/.local/bin:$PATH"
+source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
+source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
+source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -50,9 +50,14 @@ source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
 # Native Autocomplete
 ################################
 
-# Remap Shift+TAB to native completion (insert common prefix)
-bindkey '^[[Z' expand-or-complete
+# Remap TAB to native completion
+bindkey '^I' expand-or-complete
+setopt auto_menu
 
+# Remap Shift+TAB to zsh-autocomplete menu
+# bindkey '^[[Z' zsh-autocomplete-widget
+
+bindkey -M menuselect '^[[Z' reverse-menu-complete
 
 
 # Autojump - added from brew install info
@@ -93,3 +98,4 @@ case ":$PATH:" in
 esac
 # pnpm end
 export PATH="$HOME/.local/bin:$PATH"
+export PATH="/usr/local/bin:$PATH"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -25,9 +25,35 @@ else
  [[ ! -f $DOTFILES/zsh/.p10k-ghostty.zsh ]] || source $DOTFILES/zsh/.p10k-ghostty.zsh
 fi
 
-# The next block (interactive and source) is to make zsh-autocomplete to work
-setopt interactive_comments # weird fix for autocomplete
+#################################
+## AUTOCOMPLETE SETUP          ##
+#################################
+
+# Zsh Autocomplete
+################################
+# - Is installed via brew (see brewfile)
+# - Gives the terminal a list of command menus and bit more info
 source /opt/homebrew/share/zsh-autocomplete/zsh-autocomplete.plugin.zsh
+
+
+# Native Zsh auto completion setup
+# Docs here: https://zsh.sourceforge.io/Doc/Release/Options.html
+setopt complete_in_word   # insert common prefix on first TAB
+
+
+# Zsh Autosuggestions
+################################
+# - Is installed via git clone (see install script)
+# - Gives the 'greyed out' suggestions when typing
+source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
+
+# Native Autocomplete
+################################
+
+# Remap Shift+TAB to native completion (insert common prefix)
+bindkey '^[[Z' expand-or-complete
+
+
 
 # Autojump - added from brew install info
 [ -f /opt/homebrew/etc/profile.d/autojump.sh ] && . /opt/homebrew/etc/profile.d/autojump.sh
@@ -67,6 +93,3 @@ case ":$PATH:" in
 esac
 # pnpm end
 export PATH="$HOME/.local/bin:$PATH"
-source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
-source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
-source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh


### PR DESCRIPTION
# Description

## Currently:
- Zsh-autocomplete gives great info of commands and suggested directories, but tab completion is annoying

We are missing great visual hints as a one-liner as Zsh-autosuggestions does

# Solution
- Install zsh-autosuggestions and make Tab gives common prefix. Example `cd alt` gives this view:
  <img width="334" height="122" alt="image" src="https://github.com/user-attachments/assets/c25b0273-6107-4b7d-ba77-a1699738c452" />
- `tab` completes it to `altinn-`, `shft-tab` completes first to `altinn-` and then `altinn-autorisasjon`.

# Glitches
Oh yes, doing tab while having `~/c` will give just `/`. ¯\_(ツ)_/¯

# Bonus
- `pnpm` is added
- `..` instead of `cd ..`